### PR TITLE
Set more scoped permissions for GH token

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  pages: write
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We intend to reduce default permissions for the org, requiring the GH token permissions to be explicitly defined in the workflow.