### PR TITLE
Set python to newest version to avoid deprecation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
We had a fixed version set, that creates deprecation issues (e.g., [latest run](https://github.com/Imageomics/Collaborative-distributed-science-guide/actions/runs/17735272165/job/50395374664)).