### PR TITLE
post-release update

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,7 +32,7 @@ identifiers:
     value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/releases/tag/v1.0.2"
   - description: "The GitHub URL of the commit tagged with v1.0.2."
     type: url
-    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/<commit-hash>" # update on release
+    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/3542cbcd516038c3290b115894df9aa46d7c2674"
 keywords:
   - imageomics
   - metadata


### PR DESCRIPTION
This was the quick patch release for Zenodo metadata sync issue. NSERC grant has been manually re-added on Zenodo.