### PR TITLE
Ref #15: Add API accessible description key to HF templates

### DIFF
--- a/docs/wiki-guide/HF_DatasetCard_Template_ABC.md
+++ b/docs/wiki-guide/HF_DatasetCard_Template_ABC.md
@@ -10,6 +10,7 @@ tags:
 - animals
 - CV
 size_categories: # ex: n<1K, 1K<n<10K, 10K<n<100K, 100K<n<1M, ...
+description: # Add a short description (summary) of your dataset, this will render in searches
 ---
 
 <!--

--- a/docs/wiki-guide/HF_DatasetCard_Template_Imageomics.md
+++ b/docs/wiki-guide/HF_DatasetCard_Template_Imageomics.md
@@ -10,6 +10,7 @@ tags:
 - animals
 - CV
 size_categories: # ex: n<1K, 1K<n<10K, 10K<n<100K, 100K<n<1M, ...
+description: # Add a short description (summary) of your dataset, this will render in searches and the Imageomics Catalog
 ---
 
 <!--

--- a/docs/wiki-guide/HF_ModelCard_Template_ABC.md
+++ b/docs/wiki-guide/HF_ModelCard_Template_ABC.md
@@ -10,6 +10,7 @@ tags:
 - animals
 datasets: # Adds link if on HF & shows up on sidebar. Ex: Imageomics/TreeOfLife-10M
 metrics: # key list: https://hf.co/metrics
+model_description: # Add a short description (summary) of your model, this will render in searches
 ---
 
 <!--

--- a/docs/wiki-guide/HF_ModelCard_Template_Imageomics.md
+++ b/docs/wiki-guide/HF_ModelCard_Template_Imageomics.md
@@ -10,6 +10,7 @@ tags:
 - animals
 datasets: # Adds link if on HF & shows up on sidebar. Ex: imageomics/TreeOfLife-10M
 metrics: # key list: https://hf.co/metrics
+model_description: # Add a short description (summary) of your model, this will render in searches and the Imageomics Catalog
 ---
 
 <!--


### PR DESCRIPTION
Adds `description` and `model_description` keys to the `yaml` section of dataset and model cards, respectively, for both Imageomics and ABC. This allows the HF API to read and return the descriptions.

Closes #15.