### PR TITLE
New release citation updates

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -55,9 +55,9 @@
       "standards"
     ],
     "title": "Collaborative Distributed Science Guide",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "license": "CC0-1.0",
-    "publication_date": "2025-09-26",
+    "publication_date": "2025-10-08",
     "grants": [
         {
             "id": "021nxhr62::2118240"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,14 +25,14 @@ authors:
   given-names: "Hilmar"
   orcid: "https://orcid.org/0000-0001-9107-0714"
 cff-version: 1.2.0
-date-released: "2025-09-26"
+date-released: "2025-10-08"
 identifiers:
-  - description: "The GitHub release URL of tag v1.0.2."
+  - description: "The GitHub release URL of tag v1.1.0."
     type: url
-    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/releases/tag/v1.0.2"
-  - description: "The GitHub URL of the commit tagged with v1.0.2."
+    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/releases/tag/v1.1.0"
+  - description: "The GitHub URL of the commit tagged with v1.1.0."
     type: url
-    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/3542cbcd516038c3290b115894df9aa46d7c2674"
+    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/<commit-hash>" # update on release
 keywords:
   - imageomics
   - metadata
@@ -48,4 +48,4 @@ license: CC0-1.0
 message: "If you find these docs helpful in your research, please cite them as below."
 repository-code: "https://github.com/Imageomics/Collaborative-distributed-science-guide"
 title: "Collaborative Distributed Science Guide"
-version: "1.0.2"
+version: "1.1.0"


### PR DESCRIPTION
Follows steps outlined in our [versioning rules](https://github.com/orgs/Imageomics/projects/85?pane=info) for a new release (`CITATION.cff` and `.zenodo.json` updates, minor version due to template and larger page update: #18 & #19). Sets version 1.1.0 for release today.

Also, updates @ieyriay to preferred name for citation.

See previous update (#12) for example.