### PR TITLE
Add new release commit hash

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,7 +32,7 @@ identifiers:
     value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/releases/tag/v1.1.0"
   - description: "The GitHub URL of the commit tagged with v1.1.0."
     type: url
-    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/<commit-hash>" # update on release
+    value: "https://github.com/Imageomics/Collaborative-distributed-science-guide/tree/e6bd55c3ec310d50e90baa4dc5882093197a0cdf"
 keywords:
   - imageomics
   - metadata


### PR DESCRIPTION
Post-release update, adding the commit hash for release v1.1.0. Also made sure to manually add the NSERC grant to the [zenodo record](https://zenodo.org/records/17298270), following [versioning guidelines](https://github.com/orgs/Imageomics/projects/85/views/1?pane=info).