### PR TITLE
Add SSHRC to the footer acknowledgement

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -68,7 +68,7 @@ copyright: >
   The Imageomics Institute is funded by the US National Science Foundation's Harnessing the Data Revolution (HDR) program under <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2118240" target="_blank"><u>Award #2118240</u></a> (Imageomics: A New Frontier of Biological Information Powered by Knowledge-Guided Machine Learning).
 
   The ABC Global Center is funded by the US National Science Foundation under <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2330423&HistoricalAwards=false" target="_blank"><u>Award No. 2330423</u></a> and the Natural Sciences and Engineering Research Council of Canada under <a href="https://www.nserc-crsng.gc.ca/ase-oro/Details-Detailles_eng.asp?id=782440" target="_blank"><u>Award No. 585136</u></a>.
-  This work also draws in part on research funded by the Social Sciences and Humanities Research Council.
+  This guide draws on research funded by the Social Sciences and Humanities Research Council.
 
   Any opinions, findings, conclusions, or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation, the Natural Sciences and Engineering Research Council of Canada, or the Social Sciences and Humanities Research Council.
 


### PR DESCRIPTION
SSHRC _was_ included in the [README acknowledgement](https://github.com/Imageomics/Collaborative-distributed-science-guide?tab=readme-ov-file#acknowledgments), but didn't make it into the footer. This PR fixes that, and it will be pulled into the ABC Guide to fix it there as well (it's included in the French version on ABC).