### PR TITLE
Clarify remote options note

### DIFF
--- a/docs/wiki-guide/Git-Cherry-Pick-Guide.md
+++ b/docs/wiki-guide/Git-Cherry-Pick-Guide.md
@@ -19,7 +19,7 @@
     ```
 
     !!! note
-        If you haven't updated yet, you will only see the current repo options (`origin`):
+        If you haven't added this template repo as a remote yet, you will only see the current repo options (`origin`):
 
         ```console
         origin	git@github.com:Imageomics/Imageomics-guide.git (fetch)


### PR DESCRIPTION
State as "this template repo" for clarity (see [question](https://github.com/Imageomics/Imageomics-guide/pull/81#discussion_r2553737148)), will adjust to "the template repo" downstream.