### PR TITLE
Update to preferred name

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
   given-names: Net
   orcid: "https://orcid.org/0000-0003-2664-451X"
 - family-names: "Duan"
-  given-names: "Zoe"
+  given-names: "Yuehua"
   orcid: "https://orcid.org/0000-0002-8547-5907"
 - family-names: "Bradley"
   given-names: "John"


### PR DESCRIPTION
@zoeduan is listed in Zenodo metadata as "Yuehua Duan", but "Zoe Duan" in the citation file. This should be standardized to the former.