### PR TITLE
Add statement regarding Google Drive

### DIFF
--- a/docs/wiki-guide/Digital-Product-Lifecycle.md
+++ b/docs/wiki-guide/Digital-Product-Lifecycle.md
@@ -19,7 +19,7 @@ The following adds additional context and direction to supplement the diagram, o
     * **Datasets:** Hugging Face Dataset Repository ([Data checklist](Data-Checklist.md)).
         * For already published data usage, see the [Metadata Checklist](Metadata-Checklist.md).
     * **ML Models:** Hugging Face Model Repository ([Model checklist](Model-Checklist.md)).
-* Though alternative storage options may be discussed, **Google Drive is not an acceptable storage location for research data, models, or code**. Folder activity does not include actual file additions or deletions, so content can be changed or removed without a record of when or by whom. All research, data, models, and code must be stored in **a version controlled repository, preferably in more than one location** to ensure preservation.
+* Though alternative storage options may be discussed, **Google Drive is not an acceptable storage location for research data, models, or code**. Folder activity does not include actual file additions or deletions, so content can be changed or removed without a record of when or by whom. All research, data, models, and code must be stored in **a version controlled repository, preferably in more than one location** to ensure preservation and full provenance tracking.
 
 ### Exploration Phase
 


### PR DESCRIPTION
Specifically, we want to clarify that Google Drive is an unreliable storage location for research products. This is due to issues with version control and ease of loss (e.g., if someone's account becomes inactive and the files will disappear, but the folders remain and there's no indication of when that happened nor clear option for recovery).

I did also add a statement about maintaining specifically in a version controlled repo. OSC technically isn't unless git is initialized, though deleted data _can_ be recovered within a reasonable time.