### PR TITLE
bug: Markdownlint Action Ignore Templates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,6 @@ jobs:
           files: '**/*.md'
           files_ignore: |
             docs/wiki-guide/HF_*_Template*.md
-            mkdocs.yaml
           separator: ","
 
       # This runs the linter ONLY on the files identified above


### PR DESCRIPTION
### Summary

The markdown lint action was not ignoring files listed in the `markdownlintignore`. To ensure the linter ignores these files we must clearly define them in the linters yaml file by including what files to ignore.

### Testing

Below was tested with an added file `docs/wiki-guides/HF_test_Template.md` which had syntax the linter would raise errors to and we can see the linter ignored the file.

<img width="847" height="484" alt="image" src="https://github.com/user-attachments/assets/ff2242ff-2748-4146-9094-02fcd167d918" />

Below we can see what happens before our solution was implemented and we can see the linter was not working and instead raising errors about `HF_test_Template.md`

<img width="1446" height="694" alt="image" src="https://github.com/user-attachments/assets/3dbca9b2-e74b-4337-9306-3b31d9e05e62" />


Verification of the configuration file being respected below:

<img width="853" height="711" alt="image" src="https://github.com/user-attachments/assets/c48c9bf7-9e66-46e1-8f99-37e2f1dd2a30" />


Here is the test MD file we used to ensure the linter respects our rules in `mardownlint.json`.

````
# Test File for Markdownlint Config

## Rule MD007: Indentation (Should allow 4 spaces)

* Level 1
    * Level 2 (This uses 4 spaces. If the linter errors, the config isn't working.)

## Rule MD013: Line Length (Should be ignored)

This is an incredibly long line of text that exceeds the default 80-character limit usually enforced by markdownlint. Because MD013 is set to false, this line should not trigger any warnings or errors regardless of how long it gets.

## Rule MD026: Trailing Punctuation (Should allow only specific marks)

### This header ends with a question mark?

### This header ends with an exclamation point!

## Rule MD040: Fenced Code Language (Should be ignored)

```
This code block has no language specified. Normally, this triggers a warning, but it should be ignored now.
```

## Rule MD046: Code Block Style (Should be ignored)

    This is an indented code block (4 spaces).
    Normally, markdownlint prefers fenced blocks (```), but this should be ignored.

## Hard Tabs (Should be allowed)

*	This line uses a hard tab after the bullet point instead of a space.
````

---

**Closes #52**