### PR TITLE
Add tip to look at rendering on branch to check citation file

### DIFF
--- a/docs/wiki-guide/GitHub-Repo-Guide.md
+++ b/docs/wiki-guide/GitHub-Repo-Guide.md
@@ -115,7 +115,7 @@ Providing this file is as simple as copying the below example and filling in you
 
 === "Standard Citation File (Recommended)"
 
-    !!! tip
+    !!! tip "Pro tip"
         Pair this citation file with a [`.zenodo.json`](#zenodo-metadata) for easier DOI metadata tracking (grants, references, associated papers).
 
     ```yaml { py linenums="1" }
@@ -214,6 +214,10 @@ Providing this file is as simple as copying the below example and filling in you
         doi: 
         date-released:
     ```
+
+!!! tip "Pro tip"
+    Check your citation renders correctly on a branch. When you push the `CITATION.cff` to a branch, you can select "Cite this repository" to see if it is rendering as expected:
+    ![Screenshot of "Cite this repository" pop-up on the Collaborative Distributed Science Guide repository. It shows APA and BibTeX 'content tabs' with the beginnings of a scrollable and copiable citation](images/GH-repo-guide/citation-cff-check.png)
 
 ## Recommended Files
 

--- a/docs/wiki-guide/GitHub-Repo-Guide.md
+++ b/docs/wiki-guide/GitHub-Repo-Guide.md
@@ -216,7 +216,7 @@ Providing this file is as simple as copying the below example and filling in you
     ```
 
 !!! tip "Pro tip"
-    Check your citation renders correctly on a branch. When you push the `CITATION.cff` to a branch, you can select "Cite this repository" to see if it is rendering as expected:
+    Check whether your citation renders correctly on a branch. When you push the `CITATION.cff` to a branch and browse the repository at that branch, you can select "Cite this repository" in the righthand sidebar to see if it is rendering as expected:
     ![Screenshot of "Cite this repository" pop-up on the Collaborative Distributed Science Guide repository. It shows APA and BibTeX 'content tabs' with the beginnings of a scrollable and copiable citation](images/GH-repo-guide/citation-cff-check.png)
 
 ## Recommended Files


### PR DESCRIPTION
This seems to be a less well-known trick that is very useful to avoid non-functional citations.

Screenshot of change on page:

<img width="963" height="584" alt="Screenshot 2026-05-14 at 3 35 38 PM" src="https://github.com/user-attachments/assets/13f73945-e164-4a5a-8c37-64506b114327" />
